### PR TITLE
Optional config_out parameter for upcoming CDSP 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,6 @@ pcm.camilladsp {
       # audio program that uses this plugin.
       cpath "/path/to/camilladsp"
       
-      # config_out is the absolute path that will be passed to CamillaDSP as
-      # the YAML config file argument. The file must be readable by any user
-      # that runs an audio program that uses this plugin.  If the config_in
-      # or config_cmd options are chosen (see below) it must also be writable
-      # by those users.
-      config_out "/path/to/config_out.yaml"
-      
       #######################################################################
       # Parameter Passing Options
       #
@@ -80,6 +73,13 @@ pcm.camilladsp {
       # config_cdsp.
       #######################################################################
 
+      # config_out is the absolute path that will be passed to CamillaDSP as
+      # the YAML config file argument. The file must be readable by any user
+      # that runs an audio program that uses this plugin.  If the config_in
+      # or config_cmd options are chosen (see below) it must also be writable
+      # by those users.
+      config_out "/path/to/config_out.yaml"
+    
       # config_in is an absolute path to a YAML template the plugin will read
       # and pass along to CamillaDSP after making simple token substitutions.
       # It must be readable by any user that runs an audio program that uses

--- a/libasound_module_pcm_cdsp.c
+++ b/libasound_module_pcm_cdsp.c
@@ -1356,12 +1356,6 @@ SND_PCM_PLUGIN_DEFINE_FUNC(cdsp) {
     }
   }
 
-  if(!pcm->cargs[1]) {
-    SNDERR("Must supply config_out file parameter.");
-    err = -EINVAL;
-    goto _err;
-  }
-
   if(channels == 0) {
     if(min_channels <= 0 || max_channels <= 0) {
       SNDERR("Must supply valid channel information.");


### PR DESCRIPTION
Hi,
since it is not possible to create issues in your project, I created this pull request.

In the upcoming CamillaDSP 2.0, it is possible to have CDSP save its state in a statefile.
(start CDSP with the [--statefile](https://github.com/HEnquist/camilladsp/tree/next20#persistent-storage-of-state) <path_to_statefile> option.)
Thus, it is not necessary anymore, to pass a config file via the command line, if the `--statefile` option is used.
However, removing the `config_out`-parameter from the alsa_cdsp config, causes alsa_cdsp to throw an error on start.

Can you please update the plugin to allow this configuration?